### PR TITLE
tempy creates the directory automatically.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,6 @@ test.cb('rebuild the simplehttp2server binaries', t => {
 
   builder
     .src('https://github.com/GoogleChrome/simplehttp2server/archive/2.0.1.tar.gz')
-    .cmd(`mkdir -p ${tmp}`)
     .cmd(`sh crosscompile.sh && mv ./${path.basename(builder.tmp)}${suffix()} ${path.join(tmp, 'simplehttp2server')}`)
     .run(err => {
       t.ifError(err);


### PR DESCRIPTION
Attempting to recreate the the directory will cause the test to fail on windows.